### PR TITLE
Use window.devicePixelRatio to select hi-dpi tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,11 +39,26 @@
 		var style = (match && match[1]) || 'osm-intl';
 		var server = 'https://maps.wikimedia.org';
 
+		function bracketDevicePixelRatio() {
+			// Todo: get the available scale factors from the server
+			var brackets = [1, 1.3, 1.5, 2, 2.6, 3],
+				baseRatio = window.devicePixelRatio || 1;
+			for (var i = 0; i < brackets.length; i++) {
+				var scale = brackets[i];
+				if (scale >= baseRatio || (baseRatio - scale) < 0.1) {
+					return scale;
+				}
+			}
+			return brackets[brackets.length - 1];
+		}
+		var scale = bracketDevicePixelRatio();
+		var scalex = (scale === 1) ? '' : ('@' + scale + 'x');
+
 		<!-- Create a map -->
 		var map = L.map('map').setView([42.828, 5.328], 7);
 
 		<!-- Add a map layer -->
-		L.tileLayer(server + '/' + style + '/{z}/{x}/{y}.png', {
+		L.tileLayer(server + '/' + style + '/{z}/{x}/{y}' + scalex + '.png', {
 			maxZoom: 18,
 			attribution: 'Wikimedia maps beta | Map data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>',
 			id: 'wikipedia-map-01'


### PR DESCRIPTION
The available scale factors are hardcoded and not yet
exposed by the server in machine-readable fashion.
Update this to the recommended technique once there is
one. :)
